### PR TITLE
Only publish a costmap if it's current and fix isCurrent logic in oobstacle layer.

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -58,6 +58,7 @@ public:
 
   /**
    * @brief Get the timestamp of the last costmap update
+     @kin-changes (costmap-clearance-issue): added this function
    */
   rclcpp::Time getTimestampLastCostmapUpdate();
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -52,9 +52,14 @@ public:
   ~CostmapSubscriber() {}
 
   /**
-   * @brief A Get the costmap from topic
+   * @brief Get the costmap from topic
    */
   std::shared_ptr<Costmap2D> getCostmap();
+
+  /**
+   * @brief Get the timestamp of the last costmap update
+   */
+  rclcpp::Time getTimestampLastCostmapUpdate();
 
   /**
    * @brief Convert an occ grid message into a costmap object

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -529,10 +529,9 @@ ObstacleLayer::updateCosts(
     return;
   }
 
-  // if not current due to reset, set current now after clearing
+  // set was_reset to false again
   if (!current_ && was_reset_) {
     was_reset_ = false;
-    current_ = true;
   }
 
   if (footprint_clearing_enabled_) {
@@ -745,7 +744,6 @@ void
 ObstacleLayer::reset()
 {
   resetMaps();
-  resetBuffersLastUpdated();
   current_ = false;
   was_reset_ = true;
 }

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -532,6 +532,7 @@ ObstacleLayer::updateCosts(
   // set was_reset to false again
   if (!current_ && was_reset_) {
     was_reset_ = false;
+    // @kin-changes (costmap-clearance-issue): don't force current_ to be true here
   }
 
   if (footprint_clearing_enabled_) {
@@ -746,6 +747,9 @@ ObstacleLayer::reset()
   resetMaps();
   current_ = false;
   was_reset_ = true;
+
+  // @kin-changes (costmap-clearance-issue): Reseting the _last_updated of the individual observation buffers
+  //  (resetBuffersLastUpdated) was removed, since the buffers are not reset in this process either.
 }
 
 void

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -446,7 +446,7 @@ Costmap2DROS::mapUpdateLoop(double frequency)
 
         auto current_time = now();
         auto map_current = isCurrent();
-        if (map_current &&  // only update costmap if it's current
+        if (map_current &&  // @kin-changes (costmap-clearance-issue): only update costmap if it's current
           ((last_publish_ + publish_cycle_ < current_time) ||  // publish_cycle_ is due
           (current_time < last_publish_)))     // time has moved backwards, probably due to a switch to sim_time // NOLINT
         {

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -445,12 +445,17 @@ Costmap2DROS::mapUpdateLoop(double frequency)
         costmap_publisher_->updateBounds(x0, xn, y0, yn);
 
         auto current_time = now();
-        if ((last_publish_ + publish_cycle_ < current_time) ||  // publish_cycle_ is due
-          (current_time < last_publish_))      // time has moved backwards, probably due to a switch to sim_time // NOLINT
+        auto map_current = isCurrent();
+        if (map_current &&  // only update costmap if it's current
+          ((last_publish_ + publish_cycle_ < current_time) ||  // publish_cycle_ is due
+          (current_time < last_publish_)))     // time has moved backwards, probably due to a switch to sim_time // NOLINT
         {
           RCLCPP_DEBUG(get_logger(), "Publish costmap at %s", name_.c_str());
           costmap_publisher_->publishCostmap();
           last_publish_ = current_time;
+        }
+        else if (!map_current) {
+          RCLCPP_WARN(get_logger(), "Costmap was not published because it`s not current");
         }
       }
     }

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -53,6 +53,15 @@ std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
   return costmap_;
 }
 
+rclcpp::Time CostmapSubscriber::getTimestampLastCostmapUpdate()
+{
+  if (!costmap_received_) {
+    throw std::runtime_error("Costmap is not available");
+  }
+
+  return std::atomic_load(&costmap_msg_)->header.stamp;
+}
+
 void CostmapSubscriber::toCostmap2D()
 {
   auto current_costmap_msg = std::atomic_load(&costmap_msg_);


### PR DESCRIPTION
Only publish the costmap if it's current. Furthermore, fix `isCurrent` logic to only report true if the costmap is really current (also after a reset).