### PR TITLE
Humble

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -323,6 +323,25 @@ AmclNode::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   // reset dynamic parameter handler
   dyn_params_handler_.reset();
 
+  if (set_initial_pose_) {
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.x",
+        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.x)));
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.y",
+        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.y)));
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.z",
+        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.z)));
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.yaw",
+        rclcpp::ParameterValue(tf2::getYaw(last_published_pose_.pose.pose.orientation))));
+  }
+
   // destroy bond connection
   destroyBond();
 
@@ -381,25 +400,6 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   noise_only_update_ = false;
   recovery_run_count_ = 0;
   recovery_scan_count_ = 0;
-
-  if (set_initial_pose_) {
-    set_parameter(
-      rclcpp::Parameter(
-        "initial_pose.x",
-        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.x)));
-    set_parameter(
-      rclcpp::Parameter(
-        "initial_pose.y",
-        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.y)));
-    set_parameter(
-      rclcpp::Parameter(
-        "initial_pose.z",
-        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.z)));
-    set_parameter(
-      rclcpp::Parameter(
-        "initial_pose.yaw",
-        rclcpp::ParameterValue(tf2::getYaw(last_published_pose_.pose.pose.orientation))));
-  }
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -401,6 +401,25 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   recovery_run_count_ = 0;
   recovery_scan_count_ = 0;
 
+  if (set_initial_pose_) {
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.x",
+        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.x)));
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.y",
+        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.y)));
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.z",
+        rclcpp::ParameterValue(last_published_pose_.pose.pose.position.z)));
+    set_parameter(
+      rclcpp::Parameter(
+        "initial_pose.yaw",
+        rclcpp::ParameterValue(tf2::getYaw(last_published_pose_.pose.pose.orientation))));
+  }
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -280,7 +280,9 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
   // process incoming callbacks until we are
   active_ = true;
 
-  if (set_initial_pose_) {
+  if (init_pose_received_on_inactive) {
+    handleInitialPose(last_published_pose_);
+  } else if (set_initial_pose_) {
     auto msg = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
     msg->header.stamp = now();
@@ -291,8 +293,6 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
     msg->pose.pose.orientation = orientationAroundZAxis(initial_pose_yaw_);
 
     initialPoseReceived(msg);
-  } else if (init_pose_received_on_inactive) {
-    handleInitialPose(last_published_pose_);
   }
 
   auto node = shared_from_this();

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -285,6 +285,11 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
   } else if (set_initial_pose_) {
     auto msg = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
+    get_parameter("initial_pose.x", initial_pose_x_);
+    get_parameter("initial_pose.y", initial_pose_y_);
+    get_parameter("initial_pose.z", initial_pose_z_);
+    get_parameter("initial_pose.yaw", initial_pose_yaw_);
+
     msg->header.stamp = now();
     msg->header.frame_id = global_frame_id_;
     msg->pose.pose.position.x = initial_pose_x_;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

## Problem Statement

AMCL Node sets the wrong initial position after re-activating if no pose message was received during the activation process, as the node uses the parameters which were set during launching.

---

## Description of contribution in a few bullet points

- The initial pose parameters are now set correctly during deactivation instead of the cleanup function
- Swapped the branch order at which initial pose is being set, the node prioritizes pose message while being inactive over the parameters (it was vice versa before)

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

