### PR TITLE
Fix calculate bounds of Static Layer

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -357,11 +357,11 @@ StaticLayer::updateBounds(
 
   double wx, wy;
 
-  mapToWorld(x_, y_, wx, wy);
+  layered_costmap_->getCostmap()->mapToWorld(x_, y_, wx, wy);
   *min_x = std::min(wx, *min_x);
   *min_y = std::min(wy, *min_y);
 
-  mapToWorld(x_ + width_, y_ + height_, wx, wy);
+  layered_costmap_->getCostmap()->mapToWorld(x_ + width_, y_ + height_, wx, wy);
   *max_x = std::max(wx, *max_x);
   *max_y = std::max(wy, *max_y);
 


### PR DESCRIPTION
We need to use mapToWorld() of the layered costmap, because the static layer doesn't update its position for rolling costmaps.

This happens only in the sim, because real shuttles get the correct bounds from the observation layer.
